### PR TITLE
Assets für Gegenstände / Aufnehmbare Gegenstände 

### DIFF
--- a/Core/Animations/AnimationLoader.cs
+++ b/Core/Animations/AnimationLoader.cs
@@ -69,7 +69,8 @@ public static class AnimationLoader
             }
         };
     }
-    public static Dictionary<string, Animation> CreateSwordAnimations()
+
+    private static Dictionary<string, Animation> CreateSwordAnimations()
     {
         return new Dictionary<string, Animation>()
         {
@@ -91,7 +92,8 @@ public static class AnimationLoader
             }
         };
     }
-    public static Dictionary<string, Animation> CreatePhaserAnimations()
+
+    private static Dictionary<string, Animation> CreatePhaserAnimations()
     {
         return new Dictionary<string, Animation>()
         {
@@ -113,7 +115,8 @@ public static class AnimationLoader
             }
         };
     }
-    public static Dictionary<string, Animation> CreateKnifeAnimations()
+
+    private static Dictionary<string, Animation> CreateKnifeAnimations()
     {
         return new Dictionary<string, Animation>()
         {
@@ -135,7 +138,8 @@ public static class AnimationLoader
             }
         };
     }
-    public static Dictionary<string, Animation> CreateStickAnimations()
+
+    private static Dictionary<string, Animation> CreateStickAnimations()
     {
        return new Dictionary<string, Animation>()
         {
@@ -157,7 +161,8 @@ public static class AnimationLoader
             }
         };
     }
-    public static Dictionary<string, Animation> CreateCrowbarAnimations()
+
+    private static Dictionary<string, Animation> CreateCrowbarAnimations()
     {
         return new Dictionary<string, Animation>()
         {
@@ -192,6 +197,21 @@ public static class AnimationLoader
     public static Weapon CreatePhaserWeapon(Vector2 position)
     {
         return new Weapon(position, _texture, CreatePhaserAnimations(), new Rectangle(16 * 16, 5 * 16, 16, 16), WeaponType.RANGE, 32);
+    }
+    
+    public static Weapon CreateKnifeWeapon(Vector2 position)
+    {
+        return new Weapon(position, _texture, CreateKnifeAnimations(), new Rectangle(13 * 16, 5 * 16, 16, 16));
+    }
+    
+    public static Weapon CreateCrowbarWeapon(Vector2 position)
+    {
+        return new Weapon(position, _texture, CreateCrowbarAnimations(), new Rectangle(16 * 16, 6 * 16, 16, 16));
+    }
+    
+    public static Weapon CreateStickWeapon(Vector2 position)
+    {
+        return new Weapon(position, _texture, CreateStickAnimations(), new Rectangle(19 * 16, 6 * 16, 16, 16));
     }
     public static Consumable CreateHealthPotion(Vector2 position)
     {

--- a/Core/Animations/AnimationLoader.cs
+++ b/Core/Animations/AnimationLoader.cs
@@ -184,4 +184,32 @@ public static class AnimationLoader
     {
         return new ProjectileShot(_texture, new Rectangle(19 * 16, 5 * 16, 16, 16), weapon, aimDirection);
     }
+
+    public static Weapon CreateSwordWeapon(Vector2 position)
+    {
+        return new Weapon(position, _texture, CreateSwordAnimations(), new Rectangle(13 * 16, 6 * 16, 16, 16));
+    }
+    public static Weapon CreatePhaserWeapon(Vector2 position)
+    {
+        return new Weapon(position, _texture, CreatePhaserAnimations(), new Rectangle(16 * 16, 5 * 16, 16, 16), WeaponType.RANGE, 32);
+    }
+    public static Consumable CreateHealthPotion(Vector2 position)
+    {
+        return new Consumable(position, _texture, new Rectangle(19*16, 4*16, 16,16));
+    }
+    
+    public static Consumable CreateArmorPotion(Vector2 position)
+    {
+        return new Consumable(position, _texture, new Rectangle(20*16, 4*16, 16,16));
+    }
+    
+    public static Currency CreateCoin(Vector2 position)
+    {
+        return new Currency(position, _texture, new Rectangle(17*16, 4*16, 16,16));
+    }
+    
+    public static Currency CreateKey(Vector2 position)
+    {
+        return new Currency(position, _texture, new Rectangle(18*16, 4*16, 16,16));
+    }
 }

--- a/Core/Combat/CombatManager.cs
+++ b/Core/Combat/CombatManager.cs
@@ -140,9 +140,11 @@ public static class CombatManager
             return;
         }
     }
+  
     private static void EnemyDies(Enemy enemy, Player player)
     {
         enemy.SetAnimation("Death");
+        ItemManager.DropRandomLoot(enemy.Position);
         player.Money += enemy.MoneyReward;
         player.XpToNextLevel += enemy.XpReward;
         enemy.IsAlive = false;

--- a/Core/Combat/ItemManager.cs
+++ b/Core/Combat/ItemManager.cs
@@ -11,11 +11,7 @@ namespace ECS2022_23.Core.Combat;
 public static class ItemManager
 {
     private static List<Item> _activeItems = new List<Item>();
-    public static void Update(GameTime gameTime)
-    {
-        
-    }
-
+    
     public static void Draw(SpriteBatch spriteBatch)
     {
         foreach (var item in _activeItems)
@@ -81,22 +77,20 @@ public static class ItemManager
     {
         foreach (var item in _activeItems)
         {
-            if (item.Rectangle.Intersects(player.Rectangle))
+            if (!item.Rectangle.Intersects(player.Rectangle)) continue;
+            if (item.GetType() == typeof(Weapon))
             {
-                if (item.GetType() == typeof(Weapon))
-                {
-                    var weapon = player.Weapon;
-                    weapon.Position = player.Position;
-                    _activeItems.Add(weapon);
-                    player.Weapon = (Weapon) item;
-                }
-                else
-                {
-                    player.AddItem(item);
-                }
-                _activeItems.Remove(item);
-                return;
+                var weapon = player.Weapon;
+                weapon.Position = player.Position;
+                _activeItems.Add(weapon);
+                player.Weapon = (Weapon) item;
             }
+            else
+            {
+                player.AddItem(item);
+            }
+            _activeItems.Remove(item);
+            return;
         }
     }
 }

--- a/Core/Combat/ItemManager.cs
+++ b/Core/Combat/ItemManager.cs
@@ -54,12 +54,15 @@ public static class ItemManager
     private static Weapon GetRandomWeapon(Vector2 position)
     {
         var random = new Random();
-        var randomInt = random.Next(2);
+        var randomInt = random.Next(5);
         Debug.WriteLine("random weapon loot: " + randomInt);
         switch (randomInt)
         {
             case 0: return AnimationLoader.CreateSwordWeapon(position);
             case 1: return AnimationLoader.CreatePhaserWeapon(position);
+            case 2: return AnimationLoader.CreateCrowbarWeapon(position);
+            case 3: return AnimationLoader.CreateKnifeWeapon(position);
+            case 4: return AnimationLoader.CreateStickWeapon(position);
             default: return AnimationLoader.CreateSwordWeapon(position);
         }
     }

--- a/Core/Combat/ItemManager.cs
+++ b/Core/Combat/ItemManager.cs
@@ -1,0 +1,102 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using ECS2022_23.Core.Animations;
+using ECS2022_23.Core.Entities.Characters;
+using ECS2022_23.Core.Entities.Items;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace ECS2022_23.Core.Combat;
+
+public static class ItemManager
+{
+    private static List<Item> _activeItems = new List<Item>();
+    public static void Update(GameTime gameTime)
+    {
+        
+    }
+
+    public static void Draw(SpriteBatch spriteBatch)
+    {
+        foreach (var item in _activeItems)
+        {
+            item.DrawIcon(spriteBatch);
+        }
+    }
+
+    private static void AddItem(Item item)
+    {
+        _activeItems.Add(item);
+    }
+
+    public static void DropRandomLoot(Vector2 position)
+    {
+        var random = new Random();
+        var randomInt = random.Next(10);
+        var dropChance = 0;
+        Debug.WriteLine("randomDrop: " + randomInt);
+        if (randomInt < dropChance) return;
+        
+        randomInt = random.Next(10);
+        var weaponChance = 4;
+        Debug.WriteLine("random loot: " + randomInt);
+        if (randomInt > weaponChance)
+        {
+            AddItem(GetRandomWeapon(position));
+        }
+        else
+        {
+            AddItem(GetRandomConsumable(position));
+        }
+    }
+
+    private static Weapon GetRandomWeapon(Vector2 position)
+    {
+        var random = new Random();
+        var randomInt = random.Next(2);
+        Debug.WriteLine("random weapon loot: " + randomInt);
+        switch (randomInt)
+        {
+            case 0: return AnimationLoader.CreateSwordWeapon(position);
+            case 1: return AnimationLoader.CreatePhaserWeapon(position);
+            default: return AnimationLoader.CreateSwordWeapon(position);
+        }
+    }
+    
+    private static Consumable GetRandomConsumable(Vector2 position)
+    {
+        var random = new Random();
+        var randomInt = random.Next(2);
+        Debug.WriteLine("random cons loot: " + randomInt);
+        switch (randomInt)
+        {
+            case 0: return AnimationLoader.CreateHealthPotion(position);
+            case 1: return AnimationLoader.CreateArmorPotion(position);
+            default: return AnimationLoader.CreateHealthPotion(position);
+        }
+    }
+
+    public static void PickItemUp(Player player)
+    {
+        foreach (var item in _activeItems)
+        {
+            if (item.Rectangle.Intersects(player.Rectangle))
+            {
+                if (item.GetType() == typeof(Weapon))
+                {
+                    var weapon = player.Weapon;
+                    weapon.Position = player.Position;
+                    _activeItems.Add(weapon);
+                    player.Weapon = (Weapon) item;
+                }
+                else
+                {
+                    player.AddItem(item);
+                }
+                _activeItems.Remove(item);
+                return;
+            }
+        }
+    }
+}

--- a/Core/Combat/ItemManager.cs
+++ b/Core/Combat/ItemManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using ECS2022_23.Core.Animations;
 using ECS2022_23.Core.Entities.Characters;
 using ECS2022_23.Core.Entities.Items;
@@ -34,13 +33,13 @@ public static class ItemManager
     {
         var random = new Random();
         var randomInt = random.Next(10);
-        var dropChance = 0;
-        Debug.WriteLine("randomDrop: " + randomInt);
+        var dropChance = 6;
+        
         if (randomInt < dropChance) return;
         
         randomInt = random.Next(10);
         var weaponChance = 4;
-        Debug.WriteLine("random loot: " + randomInt);
+
         if (randomInt > weaponChance)
         {
             AddItem(GetRandomWeapon(position));
@@ -55,7 +54,6 @@ public static class ItemManager
     {
         var random = new Random();
         var randomInt = random.Next(5);
-        Debug.WriteLine("random weapon loot: " + randomInt);
         switch (randomInt)
         {
             case 0: return AnimationLoader.CreateSwordWeapon(position);
@@ -71,7 +69,6 @@ public static class ItemManager
     {
         var random = new Random();
         var randomInt = random.Next(2);
-        Debug.WriteLine("random cons loot: " + randomInt);
         switch (randomInt)
         {
             case 0: return AnimationLoader.CreateHealthPotion(position);

--- a/Core/Combat/ItemManager.cs
+++ b/Core/Combat/ItemManager.cs
@@ -29,7 +29,7 @@ public static class ItemManager
     {
         var random = new Random();
         var randomInt = random.Next(10);
-        var dropChance = 6;
+        var dropChance = 0;
         
         if (randomInt < dropChance) return;
         

--- a/Core/Entities/Characters/Player.cs
+++ b/Core/Entities/Characters/Player.cs
@@ -216,6 +216,8 @@ public class Player : Character
 
     public void UseItem(Item item)
     {
-        item.Use();
+        if (Items.Count <= 0) return;
+        if (!Items.Remove(item)) return;
+        item.Use(this);
     }
 }

--- a/Core/Entities/Characters/enemy/Enemy.cs
+++ b/Core/Entities/Characters/enemy/Enemy.cs
@@ -7,8 +7,8 @@ namespace ECS2022_23.Core.Entities.Characters.enemy;
 
 public  class Enemy : Character
 {
-    public float XpReward;
-    public float MoneyReward;
+    public float XpReward = 5;
+    public float MoneyReward = 10;
     private Motor _motor;
     public bool IsActive = true;
 

--- a/Core/Entities/Items/Consumable.cs
+++ b/Core/Entities/Items/Consumable.cs
@@ -1,12 +1,13 @@
-﻿using Microsoft.Xna.Framework;
+﻿using ECS2022_23.Core.Entities.Characters;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace ECS2022_23.Core.Entities.Items;
 
 public class Consumable : Item
 {
-    public float HealPoints { get; set; } = 10;
-    public float XpPoints { get; set; } = 5;
+    public float HealPoints { get; set; } = 2;
+    public float XpPoints { get; set; } = 1;
     public float DamageMultiplier { get; set; } = 1f;
     public float Duration { get; set; } = 10f;
     public Consumable(Vector2 spawn, Texture2D texture, Rectangle sourceRect) : base(spawn, texture, sourceRect)
@@ -17,4 +18,11 @@ public class Consumable : Item
     {
         throw new System.NotImplementedException();
     }
+
+    public override void Use(Player player)
+    {
+        player.HP += HealPoints;
+        player.XpToNextLevel += XpPoints;
+    }
+
 }

--- a/Core/Entities/Items/Consumable.cs
+++ b/Core/Entities/Items/Consumable.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace ECS2022_23.Core.Entities.Items;
+
+public class Consumable : Item
+{
+    public float HealPoints { get; set; } = 10;
+    public float XpPoints { get; set; } = 5;
+    public float DamageMultiplier { get; set; } = 1f;
+    public float Duration { get; set; } = 10f;
+    public Consumable(Vector2 spawn, Texture2D texture, Rectangle sourceRect) : base(spawn, texture, sourceRect)
+    {
+    }
+
+    public override void Update(GameTime gameTime)
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/Core/Entities/Items/Currency.cs
+++ b/Core/Entities/Items/Currency.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace ECS2022_23.Core.Entities.Items;
+
+public class Currency : Item
+{
+    public float Value { get; set; } = 10;
+    
+    public Currency(Vector2 spawn, Texture2D texture, Rectangle sourceRect) : base(spawn, texture, sourceRect)
+    {
+    }
+
+    public override void Update(GameTime gameTime)
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/Core/Entities/Items/Item.cs
+++ b/Core/Entities/Items/Item.cs
@@ -5,13 +5,24 @@ namespace ECS2022_23.Core.Entities.Items;
 
 public abstract class Item : Entity
 {
-
-    protected Item(Vector2 spawn,Texture2D texture) : base(spawn, texture)
+    public Rectangle SourceRect { get; }
+    protected Item(Vector2 spawn,Texture2D texture, Rectangle sourceRect) : base(spawn, texture)
     {
+        SourceRect = sourceRect;
     }
 
     public virtual void Use()
     {
         
+    }
+
+    public override void Draw(SpriteBatch spriteBatch)
+    {
+        spriteBatch.Draw(Texture, Position, SourceRect, Color.White);
+    }
+    
+    public void DrawIcon(SpriteBatch spriteBatch)
+    {
+        spriteBatch.Draw(Texture, Position, SourceRect, Color.White);
     }
 }

--- a/Core/Entities/Items/Item.cs
+++ b/Core/Entities/Items/Item.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using ECS2022_23.Core.Entities.Characters;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace ECS2022_23.Core.Entities.Items;
@@ -15,7 +16,10 @@ public abstract class Item : Entity
     {
         
     }
-
+    public virtual void Use(Player player)
+    {
+        
+    }
     public override void Draw(SpriteBatch spriteBatch)
     {
         spriteBatch.Draw(Texture, Position, SourceRect, Color.White);

--- a/Core/Entities/Items/Trinket.cs
+++ b/Core/Entities/Items/Trinket.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace ECS2022_23.Core.Entities.Items;
+
+public class Trinket : Item
+{
+    public float DamageMultiplier { get; set; } = 2f;
+    public float XpMultiplier { get; set; } = 2f;
+    public float ArmorMultiplier { get; set; } = 2f;
+    public Trinket(Vector2 spawn, Texture2D texture, Rectangle sourceRect) : base(spawn, texture, sourceRect)
+    {
+    }
+
+    public override void Update(GameTime gameTime)
+    {
+        throw new System.NotImplementedException();
+    }
+}

--- a/Core/Entities/Items/Trinket.cs
+++ b/Core/Entities/Items/Trinket.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+﻿using ECS2022_23.Core.Entities.Characters;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace ECS2022_23.Core.Entities.Items;
@@ -15,5 +16,12 @@ public class Trinket : Item
     public override void Update(GameTime gameTime)
     {
         throw new System.NotImplementedException();
+    }
+    
+    public override void Use(Player player)
+    {
+        player.Strength *= DamageMultiplier;
+        player.XpToNextLevel *= XpMultiplier;
+        player.Armor *= ArmorMultiplier;
     }
 }

--- a/Core/Entities/Items/Weapon.cs
+++ b/Core/Entities/Items/Weapon.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.Specialized;
 using ECS2022_23.Core.Animations;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
@@ -7,19 +8,18 @@ namespace ECS2022_23.Core.Entities.Items;
 
 public class Weapon : Item
 {
-    public float DamagePoints;
+    public float DamagePoints = 5;
     public float Range { get; }
-    public WeaponType WeaponType;
+    public WeaponType WeaponType = WeaponType.CLOSE;
 
-    public Weapon(Vector2 spawn, Texture2D texture, Vector2 startPos, Dictionary<string, Animation> animations) : base(spawn, texture)
+    public Weapon(Vector2 spawn, Texture2D texture, Dictionary<string, Animation> animations, Rectangle sourceRect) : base(spawn, texture, sourceRect)
     {
         Animations = animations;
     }
-    public Weapon(Texture2D texture, Vector2 startPos, Dictionary<string, Animation> animations, WeaponType type, float range) : base(Vector2.Zero, texture)
+    public Weapon(Vector2 spawn, Texture2D texture, Dictionary<string, Animation> animations, Rectangle sourceRect, WeaponType type, float range) : base(spawn, texture, sourceRect)
     {
         Animations = animations;
         Range = range;
-        DamagePoints = 2;
         WeaponType = type;
     }
     

--- a/Core/Input.cs
+++ b/Core/Input.cs
@@ -1,4 +1,5 @@
-﻿using ECS2022_23.Core.Entities.Characters;
+﻿using ECS2022_23.Core.Combat;
+using ECS2022_23.Core.Entities.Characters;
 using ECS2022_23.Enums;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
@@ -24,6 +25,9 @@ public class Input
         if (Keyboard.GetState().IsKeyDown(Keys.Space) && prevState != Keyboard.GetState())
         {
             _player.Attack();
+        } else if (Keyboard.GetState().IsKeyDown(Keys.X) && prevState != Keyboard.GetState())
+        {
+            ItemManager.PickItemUp(_player);
         } 
         
         // Diagonal Movement

--- a/Core/Input.cs
+++ b/Core/Input.cs
@@ -1,5 +1,6 @@
 ﻿using ECS2022_23.Core.Combat;
 using ECS2022_23.Core.Entities.Characters;
+using ECS2022_23.Core.Ui;
 using ECS2022_23.Enums;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
@@ -28,6 +29,20 @@ public class Input
         } else if (Keyboard.GetState().IsKeyDown(Keys.X) && prevState != Keyboard.GetState())
         {
             ItemManager.PickItemUp(_player);
+        } else if (Keyboard.GetState().IsKeyDown(Keys.D1) && prevState != Keyboard.GetState())
+        {
+            if (_player.Items?.Count > 0)
+            {
+                var item = UiManager.UseItemAtIndex(1, _player);
+                if(item != null) _player.UseItem(item);
+            }
+        } else if (Keyboard.GetState().IsKeyDown(Keys.D2) && prevState != Keyboard.GetState())
+        {
+            if (_player.Items?.Count > 0)
+            {
+                var item = UiManager.UseItemAtIndex(3, _player);
+                if(item != null) _player.UseItem(item);
+            }
         } 
         
         // Diagonal Movement

--- a/Core/Ui/UILabels.cs
+++ b/Core/Ui/UILabels.cs
@@ -6,7 +6,10 @@ public enum UiLabels
     CoinIcon,
     XpIcon,
     Heart,
-    TopContainer,
+    StatsContainer,
     CoinText,
-    XpText
+    XpText,
+    ItemContainer,
+    WeaponIcon,
+    ItemIcon
 }

--- a/Core/Ui/UILabels.cs
+++ b/Core/Ui/UILabels.cs
@@ -11,5 +11,10 @@ public enum UiLabels
     XpText,
     ItemContainer,
     WeaponIcon,
-    ItemIcon
+    HealthItemIcon,
+    HealthText,
+    ArmorItemIcon,
+    ArmorText,
+    ItemIcon,
+    ItemText,
 }

--- a/Core/Ui/UILoader.cs
+++ b/Core/Ui/UILoader.cs
@@ -14,7 +14,7 @@ internal static class UiLoader
     private static ContentManager _content;
     private static Texture2D _texture2D;
     private static SpriteFont _font;
-    public static void Load(UiManager uiManager, ContentManager content)
+    public static void Load(ContentManager content)
     
     {
         if (!Directory.Exists("Content")) throw new DirectoryNotFoundException();
@@ -32,8 +32,12 @@ internal static class UiLoader
             statsContainer.Add(CreateXpIcon());
             statsContainer.Add(CreateTextElement(UiLabels.XpText));
             UiPanel itemContainer = CreateUiPanel(new Rectangle(0,0, PixelSize, PixelSize), new Rectangle(0,Game1.ScreenHeight-16,Game1.ScreenWidth, 100), UiLabels.ItemContainer);
-            uiManager.StatsPanel = statsContainer;
-            uiManager.ItemPanel = itemContainer;
+            itemContainer.Add(CreateIcon(new Rectangle(19*16, 4*16, PixelSize, PixelSize), UiLabels.HealthItemIcon));
+            itemContainer.Add(CreateTextElement(UiLabels.HealthText));
+            itemContainer.Add(CreateIcon(new Rectangle(20*16, 4*16, PixelSize, PixelSize), UiLabels.ArmorItemIcon));
+            itemContainer.Add(CreateTextElement(UiLabels.ArmorText));
+            UiManager.StatsPanel = statsContainer;
+            UiManager.ItemPanel = itemContainer;
         }
         catch (Exception e)
         {
@@ -61,7 +65,7 @@ internal static class UiLoader
         return new UiElement(new Rectangle(16*16, 4*16, PixelSize, PixelSize), _texture2D, UiLabels.Heart);
     }
 
-    private static UiText CreateTextElement(UiLabels uiLabel)
+    public static UiText CreateTextElement(UiLabels uiLabel)
     {
         return new UiText(new Rectangle(0,0, PixelSize, PixelSize), _font, "0", uiLabel);
     }

--- a/Core/Ui/UILoader.cs
+++ b/Core/Ui/UILoader.cs
@@ -25,13 +25,15 @@ internal static class UiLoader
             _texture2D = _content.Load<Texture2D>("sprites/spritesheet");
             _font = _content.Load<SpriteFont>("fonts/rainyhearts");
         
-            UiPanel topContainer = CreateTopContainer();
-            topContainer.Add(CreateHpIcon());
-            topContainer.Add(CreateCoinIcon());
-            topContainer.Add(CreateTextElement(UiLabels.CoinText));
-            topContainer.Add(CreateXpIcon());
-            topContainer.Add(CreateTextElement(UiLabels.XpText));
-            uiManager.AddPanel(topContainer);
+            UiPanel statsContainer = CreateUiPanel(new Rectangle(0,0, PixelSize, PixelSize), new Rectangle(0,0, Game1.ScreenWidth, 100), UiLabels.StatsContainer);
+            statsContainer.Add(CreateHpIcon());
+            statsContainer.Add(CreateCoinIcon());
+            statsContainer.Add(CreateTextElement(UiLabels.CoinText));
+            statsContainer.Add(CreateXpIcon());
+            statsContainer.Add(CreateTextElement(UiLabels.XpText));
+            UiPanel itemContainer = CreateUiPanel(new Rectangle(0,0, PixelSize, PixelSize), new Rectangle(0,Game1.ScreenHeight-16,Game1.ScreenWidth, 100), UiLabels.ItemContainer);
+            uiManager.StatsPanel = statsContainer;
+            uiManager.ItemPanel = itemContainer;
         }
         catch (Exception e)
         {
@@ -59,14 +61,19 @@ internal static class UiLoader
         return new UiElement(new Rectangle(16*16, 4*16, PixelSize, PixelSize), _texture2D, UiLabels.Heart);
     }
 
-    private static UiPanel CreateTopContainer()
-    {
-        return new UiPanel(new Rectangle(0,0, PixelSize, PixelSize), new Rectangle(0,0, Game1.ScreenWidth, 100), UiLabels.TopContainer);
-    }
-    
     private static UiText CreateTextElement(UiLabels uiLabel)
     {
         return new UiText(new Rectangle(0,0, PixelSize, PixelSize), _font, "0", uiLabel);
+    }
+    
+    public static UiElement CreateIcon(Rectangle sourceRect, UiLabels label)
+    {
+        return new UiElement(sourceRect, _texture2D, label);
+    }
+
+    private static UiPanel CreateUiPanel(Rectangle sourceRect, Rectangle destRect, UiLabels label)
+    {
+        return new UiPanel(sourceRect, destRect, label);
     }
     
 }

--- a/Core/Ui/UIManager.cs
+++ b/Core/Ui/UIManager.cs
@@ -1,20 +1,21 @@
-﻿using ECS2022_23.Core.Entities.Characters;
+﻿using System.Linq;
+using ECS2022_23.Core.Entities.Characters;
 using ECS2022_23.Core.Entities.Items;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace ECS2022_23.Core.Ui;
 
-public class UiManager
+public static class UiManager
 {
-    public UiPanel StatsPanel { get; set; }
-    public UiPanel ItemPanel { get; set; }
-    private int _preHeartCount;
-    private Weapon _preWeapon;
-    private int _preItemCount;
-    private bool _statsHaveChanged;
-    private bool _itemsHaveChanged;
+    public static UiPanel StatsPanel { get; set; }
+    public static UiPanel ItemPanel { get; set; }
+    private static int _preHeartCount;
+    private static Weapon _preWeapon;
+    private static int _preItemCount;
+    private static bool _statsHaveChanged;
+    private static bool _itemsHaveChanged;
     
-    public void Update(Player player)
+    public static void Update(Player player)
     {
         _statsHaveChanged = false;
         _itemsHaveChanged = false;
@@ -30,12 +31,12 @@ public class UiManager
         ItemPanel.Update();
     }
 
-    public void Draw(SpriteBatch spriteBatch)
+    public static void Draw(SpriteBatch spriteBatch)
     {
         StatsPanel.Draw(spriteBatch);
         ItemPanel.Draw(spriteBatch);
     }
-    private void UpdateHearts(Player player)
+    private static void UpdateHearts(Player player)
     {
         var heartCount = (int) player.HP;
         if (heartCount == _preHeartCount) return;
@@ -71,13 +72,13 @@ public class UiManager
         _statsHaveChanged = true;
     }
 
-    private void UpdateText(UiLabels label, float stats)
+    private static void UpdateText(UiPanel panel, UiLabels label, float stats)
     {
-        UiText uiText = (UiText) StatsPanel.GetComponentByLabel(label);
+        UiText uiText = (UiText) panel.GetComponentByLabel(label);
         if (uiText == null) return;
         if (uiText.Text == $"{stats:0.##}") return;
        
-        uiText.Text = stats <= 0 ? "0.00" : $"{stats:0.##}";
+        uiText.Text = stats <= 0 ? "0" : $"{stats:0.##}";
         uiText.SourceRec.Width = (int) uiText.Font.MeasureString(uiText.Text).X;
         uiText.SourceRec.Height = (int) uiText.Font.MeasureString(uiText.Text).Y;
         _statsHaveChanged = true;
@@ -88,34 +89,91 @@ public class UiManager
         return component.UiLabel == UiLabels.Heart;
     }
 
-    private void UpdateInventory(Player player)
+    private static void UpdateInventory(Player player)
     {
       UpdateItems(player);
       UpdateWeapon(player);
     }
 
-    private void UpdateStats(Player player)
+    private static void UpdateStats(Player player)
     {
         UpdateHearts(player);
-        UpdateText(UiLabels.CoinText, player.Money);
-        UpdateText(UiLabels.XpText, player.XpToNextLevel);
+        UpdateText(StatsPanel, UiLabels.CoinText, player.Money);
+        UpdateText(StatsPanel, UiLabels.XpText, player.XpToNextLevel);
     }
 
-    private void UpdateItems(Player player)
+    /*
+    private static void UpdateItems(Player player)
     {
         var items = player.Items;
         if (items == null) return;
         if(items.Count == _preItemCount) return;
+
+        var itemGroups = items
+            .GroupBy(item => item.SourceRect)
+            .Select(grp => grp.ToList())
+            .ToList();
         ItemPanel.RemoveAll(component => component.UiLabel == UiLabels.ItemIcon);
-        foreach (var item in items)
+        ItemPanel.RemoveAll(component => component.UiLabel == UiLabels.ItemText);
+        foreach (var group in itemGroups)
         {
-            ItemPanel.Add(UiLoader.CreateIcon(item.SourceRect, UiLabels.ItemIcon));
+            var sourceRec = group.First().SourceRect;
+            ItemPanel.Add(UiLoader.CreateIcon(sourceRec, UiLabels.ItemIcon));
+            var text = UiLoader.CreateTextElement(UiLabels.ItemText);
+            text.Text = ""+group.Count;
+            ItemPanel.Add(text);
+        }
+        _itemsHaveChanged = true;
+        _preItemCount = items.Count;
+    }
+    */
+    
+    private static void UpdateItems(Player player)
+    {
+        var items = player.Items;
+        if (items == null) return;
+        if(items.Count == _preItemCount) return;
+
+        var itemGroups = items
+            .GroupBy(item => item.SourceRect)
+            .Select(grp => grp.ToList())
+            .ToList();
+        UpdateText(ItemPanel,UiLabels.HealthText, 0);
+        UpdateText(ItemPanel, UiLabels.ArmorText, 0);
+        foreach (var group in itemGroups)
+        {
+            var sourceRec = group.First().SourceRect;
+            var healthItem = ItemPanel.GetComponentByLabel(UiLabels.HealthItemIcon);
+            var armorItem = ItemPanel.GetComponentByLabel(UiLabels.ArmorItemIcon);
+            if (sourceRec == healthItem.SourceRec)
+            {
+                UpdateText(ItemPanel,UiLabels.HealthText, group.Count);
+            } else if (sourceRec == armorItem.SourceRec)
+            {
+                UpdateText(ItemPanel, UiLabels.ArmorText, group.Count);
+            }
+            else
+            {
+                var index = ItemPanel.GetIndexFromLabel(UiLabels.ArmorText);
+                var delete = true;
+                while (delete)
+                {
+                    if (!ItemPanel.RemoveAtIndex(index + 1, UiLabels.ItemIcon) &&
+                        !ItemPanel.RemoveAtIndex(index + 1, UiLabels.ItemText))
+                        delete = false;
+                }
+                ItemPanel.Add(UiLoader.CreateIcon(sourceRec, UiLabels.ItemIcon));
+                var text = UiLoader.CreateTextElement(UiLabels.ItemText);
+                text.Text = ""+group.Count;
+                ItemPanel.Add(text);
+            }
+           
         }
         _itemsHaveChanged = true;
         _preItemCount = items.Count;
     }
     
-    private void UpdateWeapon(Player player) {
+    private static void UpdateWeapon(Player player) {
     
         if (player.Weapon == null || player.Weapon == _preWeapon) return;
         
@@ -128,11 +186,17 @@ public class UiManager
         }
         else
         {
-            ItemPanel.Add(UiLoader.CreateIcon(weapon.SourceRect, UiLabels.WeaponIcon));
+            ItemPanel.InsertAtIndex(UiLoader.CreateIcon(weapon.SourceRect, UiLabels.WeaponIcon), 0);
         }
 
         _preWeapon = weapon;
         _itemsHaveChanged = true;
     }
 
+    public static Item UseItemAtIndex(int index, Player player)
+    {
+        if (index <= 0) return null;
+        var component = ItemPanel.GetComponentAtIndex(index);
+        return player.Items.Find(item => item.SourceRect == component.SourceRec);
+    }
 }

--- a/Core/Ui/UIManager.cs
+++ b/Core/Ui/UIManager.cs
@@ -1,39 +1,45 @@
 ﻿using ECS2022_23.Core.Entities.Characters;
+using ECS2022_23.Core.Entities.Items;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace ECS2022_23.Core.Ui;
 
 public class UiManager
 {
-    private UiPanel _panel;
+    public UiPanel StatsPanel { get; set; }
+    public UiPanel ItemPanel { get; set; }
     private int _preHeartCount;
-    private bool _hasChanged;
-    public void AddPanel(UiPanel panel)
-    {
-        _panel = panel;
-    }
-
+    private Weapon _preWeapon;
+    private int _preItemCount;
+    private bool _statsHaveChanged;
+    private bool _itemsHaveChanged;
+    
     public void Update(Player player)
     {
-        _hasChanged = false;
-        UpdateHearts(player);
-        UpdateText(UiLabels.CoinText, player.Money);
-        UpdateText(UiLabels.XpText, player.XpToNextLevel);
-        if (_hasChanged)
+        _statsHaveChanged = false;
+        _itemsHaveChanged = false;
+        
+        UpdateStats(player);
+        if (_statsHaveChanged)
         {
-            _panel.Update();
+            StatsPanel.Update();
         }
+
+        UpdateInventory(player);
+        if (!_itemsHaveChanged) return;
+        ItemPanel.Update();
     }
 
     public void Draw(SpriteBatch spriteBatch)
     {
-        _panel.Draw(spriteBatch);
+        StatsPanel.Draw(spriteBatch);
+        ItemPanel.Draw(spriteBatch);
     }
     private void UpdateHearts(Player player)
     {
         var heartCount = (int) player.HP;
         if (heartCount == _preHeartCount) return;
-        var index = _panel.GetIndexFromLabel(UiLabels.HpIcon);
+        var index = StatsPanel.GetIndexFromLabel(UiLabels.HpIcon);
         if (index < 0) return;
 
         if (heartCount > 0)
@@ -45,41 +51,88 @@ public class UiManager
             {
                 for (int i = 1; i <= change; i++)
                 {
-                    _panel.InsertAtIndex(UiLoader.CreateHeart(), index+i);
+                    StatsPanel.InsertAtIndex(UiLoader.CreateHeart(), index+i);
                 }
             } else if (change < 0)
             {
                 change *= -1;
                 for (int i = 1; i <= change; i++)
                 {
-                    _panel.RemoveAtIndex(index+i,UiLabels.Heart);
+                    StatsPanel.RemoveAtIndex(index+i,UiLabels.Heart);
                 }
             }
             _preHeartCount = heartCount;
         } else 
         {
             _preHeartCount = 0;
-            _panel.RemoveAll(HasHeartLabel);
+            StatsPanel.RemoveAll( component => component.UiLabel == UiLabels.Heart);
         }
 
-        _hasChanged = true;
+        _statsHaveChanged = true;
     }
 
     private void UpdateText(UiLabels label, float stats)
     {
-        UiText uiText = (UiText) _panel.GetComponentByLabel(label);
+        UiText uiText = (UiText) StatsPanel.GetComponentByLabel(label);
         if (uiText == null) return;
         if (uiText.Text == $"{stats:0.##}") return;
        
         uiText.Text = stats <= 0 ? "0.00" : $"{stats:0.##}";
         uiText.SourceRec.Width = (int) uiText.Font.MeasureString(uiText.Text).X;
         uiText.SourceRec.Height = (int) uiText.Font.MeasureString(uiText.Text).Y;
-        _hasChanged = true;
+        _statsHaveChanged = true;
     }
 
     private static bool HasHeartLabel(Component component)
     {
         return component.UiLabel == UiLabels.Heart;
+    }
+
+    private void UpdateInventory(Player player)
+    {
+      UpdateItems(player);
+      UpdateWeapon(player);
+    }
+
+    private void UpdateStats(Player player)
+    {
+        UpdateHearts(player);
+        UpdateText(UiLabels.CoinText, player.Money);
+        UpdateText(UiLabels.XpText, player.XpToNextLevel);
+    }
+
+    private void UpdateItems(Player player)
+    {
+        var items = player.Items;
+        if (items == null) return;
+        if(items.Count == _preItemCount) return;
+        ItemPanel.RemoveAll(component => component.UiLabel == UiLabels.ItemIcon);
+        foreach (var item in items)
+        {
+            ItemPanel.Add(UiLoader.CreateIcon(item.SourceRect, UiLabels.ItemIcon));
+        }
+        _itemsHaveChanged = true;
+        _preItemCount = items.Count;
+    }
+    
+    private void UpdateWeapon(Player player) {
+    
+        if (player.Weapon == null || player.Weapon == _preWeapon) return;
+        
+        var index = ItemPanel.GetIndexFromLabel(UiLabels.WeaponIcon);
+        var weapon = player.Weapon;
+        if (index >= 0)
+        {
+            ItemPanel.RemoveAtIndex(index, UiLabels.WeaponIcon);
+            ItemPanel.InsertAtIndex(UiLoader.CreateIcon(weapon.SourceRect, UiLabels.WeaponIcon), index);
+        }
+        else
+        {
+            ItemPanel.Add(UiLoader.CreateIcon(weapon.SourceRect, UiLabels.WeaponIcon));
+        }
+
+        _preWeapon = weapon;
+        _itemsHaveChanged = true;
     }
 
 }

--- a/Core/Ui/UIPanel.cs
+++ b/Core/Ui/UIPanel.cs
@@ -10,9 +10,16 @@ public class UiPanel : Component
 {
     private List<Component> _components;
     private Texture2D _texture2D;
+    private int _scale = 2;
     public UiPanel(Rectangle sourceRec, Rectangle destRec, UiLabels uiLabel) : base(sourceRec)
     {
         DestinationRec = destRec;
+        DestinationRec.Height *= _scale;
+        DestinationRec.Width *= _scale;
+        if (DestinationRec.Y != 0)
+        {
+            DestinationRec.Y -= (_scale-1) * 16;
+        }
         _components = new List<Component>();
         UiLabel = uiLabel;
     }
@@ -72,15 +79,15 @@ public class UiPanel : Component
         {
             component.DestinationRec.X = DestinationRec.X + preWidth;
             component.DestinationRec.Y = DestinationRec.Y;
-            preWidth += component.SourceRec.Width;
+            preWidth += component.SourceRec.Width*_scale;
             SetLength(component);
         }
     }
 
     private void SetLength(Component component)
     {
-        component.DestinationRec.Width = component.SourceRec.Width;
-        component.DestinationRec.Height = component.SourceRec.Height;
+        component.DestinationRec.Width = component.SourceRec.Width*_scale;
+        component.DestinationRec.Height = component.SourceRec.Height*_scale;
     }
 
     public void InsertAtIndex(Component component, int index)

--- a/Core/Ui/UIPanel.cs
+++ b/Core/Ui/UIPanel.cs
@@ -41,6 +41,11 @@ public class UiPanel : Component
     {
         _components.Add(component);
         component.DestinationRec = DestinationRec;
+        if (component.GetType() == typeof(UiText))
+        {
+            var uitext = (UiText)component;
+            uitext.Scale = new Vector2(_scale, _scale);
+        }
         SetPositions();
     }
 

--- a/Core/Ui/UIPanel.cs
+++ b/Core/Ui/UIPanel.cs
@@ -40,12 +40,7 @@ public class UiPanel : Component
     public void Add(Component component)
     {
         _components.Add(component);
-        component.DestinationRec = DestinationRec;
-        if (component.GetType() == typeof(UiText))
-        {
-            var uitext = (UiText)component;
-            uitext.Scale = new Vector2(_scale, _scale);
-        }
+        SetScaling(component);
         SetPositions();
     }
 
@@ -89,6 +84,14 @@ public class UiPanel : Component
         }
     }
 
+    private void SetScaling(Component component)
+    {
+        component.DestinationRec = DestinationRec;
+        if (component.GetType() != typeof(UiText)) return;
+        var uiText = (UiText)component;
+        uiText.Scale = new Vector2(_scale, _scale);
+    }
+
     private void SetLength(Component component)
     {
         component.DestinationRec.Width = component.SourceRec.Width*_scale;
@@ -99,12 +102,13 @@ public class UiPanel : Component
     {
         if (index < 0) return;
         _components.Insert(index, component);
+        SetScaling(component);
         SetPositions();
     }
 
-    public void RemoveAtIndex(int index, UiLabels componentUiLabel)
+    public bool RemoveAtIndex(int index, UiLabels componentUiLabel)
     {
-        if (index < 0 || index > _components.Count) return;
+        if (index < 0 || index > _components.Count) return false;
         
         try
         {
@@ -114,6 +118,7 @@ public class UiPanel : Component
             {
                 _components.RemoveAt(index);
                 SetPositions();
+                return true;
             }
             
         }
@@ -121,7 +126,8 @@ public class UiPanel : Component
         {
             Debug.WriteLine(e.Message);
         }
-      
+
+        return false;
     }
 
     public int GetIndexFromLabel(UiLabels uiLabel)
@@ -167,5 +173,13 @@ public class UiPanel : Component
 
         return null;
     }
+    public Component Find(Predicate<Component> cPredicate)
+    {
+        return _components.Find(cPredicate);
+    }
     
+    public int GetIndexFromComponent(Component component)
+    {
+        return _components.IndexOf(component);
+    }
 }

--- a/Core/Ui/UIText.cs
+++ b/Core/Ui/UIText.cs
@@ -7,7 +7,7 @@ public class UiText : Component
 {
     public SpriteFont Font { get; set; }
     public string Text { get; set; }
-
+    public Vector2 Scale { get; set; } = Vector2.One;
     public UiText(Rectangle sourceRec, SpriteFont font, string text, UiLabels uiLabel) : base(sourceRec)
     {
         Font = font;
@@ -17,6 +17,6 @@ public class UiText : Component
 
     public override void Draw(SpriteBatch spriteBatch)
     {
-        spriteBatch.DrawString(Font, Text, new Vector2(DestinationRec.X, DestinationRec.Y), Color.White);
+        spriteBatch.DrawString(Font, Text, new Vector2(DestinationRec.X, DestinationRec.Y), Color.White, 0f, Vector2.Zero, Scale, SpriteEffects.None, 0f);
     }
 }

--- a/Game1.cs
+++ b/Game1.cs
@@ -81,7 +81,6 @@ public class Game1 : Game
         UiManager.Update(_player);
         _enemy.Update(gameTime);
         CombatManager.Update(gameTime, _player);
-        ItemManager.Update(gameTime);
         base.Update(gameTime);
     }
     protected override void Draw(GameTime gameTime)

--- a/Game1.cs
+++ b/Game1.cs
@@ -1,4 +1,4 @@
-using Comora;
+﻿using Comora;
 using ECS2022_23.Core;
 using ECS2022_23.Core.Animations;
 using ECS2022_23.Core.Combat;
@@ -25,6 +25,8 @@ public class Game1 : Game
     private Escape _escape;
     private Player _player;
     private Enemy _enemy;
+    private Enemy _enemy2;
+    private Enemy _enemy3;
     public static int ScreenWidth = 1280;
     public static int ScreenHeight = 720;
     
@@ -56,12 +58,16 @@ public class Game1 : Game
         _spriteBatch = new SpriteBatch(GraphicsDevice);
         AnimationLoader.Load(Content);
         _player = new Player(Content.Load<Texture2D>("sprites/astro"), AnimationLoader.CreatePlayerAnimations());
-        _player.Weapon = new Weapon(Content.Load<Texture2D>("sprites/spritesheet"),Vector2.Zero,AnimationLoader.CreatePhaserAnimations(), WeaponType.RANGE, 32);
+        _player.Weapon = AnimationLoader.CreatePhaserWeapon(Vector2.Zero);
         
         _escape = new Escape(_player, 3, false);
         _escape.AttachCamera(_camera);
         _enemy = new Enemy(_player.Position, Content.Load<Texture2D>("sprites/spritesheet"), AnimationLoader.CreatePlayerAnimations(), new ChaseMotor(_player));
+        _enemy2 = new Enemy(_player.Position, Content.Load<Texture2D>("sprites/spritesheet"), AnimationLoader.CreatePlayerAnimations(), new ChaseMotor(_player));
+        _enemy3 = new Enemy(_player.Position, Content.Load<Texture2D>("sprites/spritesheet"), AnimationLoader.CreatePlayerAnimations(), new ChaseMotor(_player));
         CombatManager.AddEnemy(_enemy);
+        CombatManager.AddEnemy(_enemy2);
+        CombatManager.AddEnemy(_enemy3);
         _uiManager = new UiManager();
         UiLoader.Load(_uiManager, Content);
     }
@@ -76,6 +82,7 @@ public class Game1 : Game
         _uiManager.Update(_player);
         _enemy.Update(gameTime);
         CombatManager.Update(gameTime, _player);
+        ItemManager.Update(gameTime);
         base.Update(gameTime);
     }
     protected override void Draw(GameTime gameTime)
@@ -86,11 +93,15 @@ public class Game1 : Game
         
             _escape.Draw(_spriteBatch);
             _enemy.Draw(_spriteBatch);
+            _enemy2.Draw(_spriteBatch);
+            _enemy3.Draw(_spriteBatch);
             CombatManager.Draw(_spriteBatch);
+            ItemManager.Draw(_spriteBatch);
+            
         _spriteBatch.End();
         
-        _spriteBatch.Begin();
-        _uiManager.Draw(_spriteBatch);
+        _spriteBatch.Begin(samplerState: SamplerState.PointClamp);
+            _uiManager.Draw(_spriteBatch);
         _spriteBatch.End();
 
         base.Draw(gameTime);

--- a/Game1.cs
+++ b/Game1.cs
@@ -20,7 +20,6 @@ public class Game1 : Game
     private SpriteBatch _spriteBatch;
     
     private Camera _camera;
-    private UiManager _uiManager;
 
     private Escape _escape;
     private Player _player;
@@ -68,8 +67,8 @@ public class Game1 : Game
         CombatManager.AddEnemy(_enemy);
         CombatManager.AddEnemy(_enemy2);
         CombatManager.AddEnemy(_enemy3);
-        _uiManager = new UiManager();
-        UiLoader.Load(_uiManager, Content);
+       
+        UiLoader.Load(Content);
     }
 
     protected override void Update(GameTime gameTime)
@@ -79,7 +78,7 @@ public class Game1 : Game
             Exit();
         
         _escape.Update(gameTime);
-        _uiManager.Update(_player);
+        UiManager.Update(_player);
         _enemy.Update(gameTime);
         CombatManager.Update(gameTime, _player);
         ItemManager.Update(gameTime);
@@ -101,7 +100,7 @@ public class Game1 : Game
         _spriteBatch.End();
         
         _spriteBatch.Begin(samplerState: SamplerState.PointClamp);
-            _uiManager.Draw(_spriteBatch);
+            UiManager.Draw(_spriteBatch);
         _spriteBatch.End();
 
         base.Draw(gameTime);

--- a/Game1.cs
+++ b/Game1.cs
@@ -24,8 +24,7 @@ public class Game1 : Game
     private Escape _escape;
     private Player _player;
     private Enemy _enemy;
-    private Enemy _enemy2;
-    private Enemy _enemy3;
+
     public static int ScreenWidth = 1280;
     public static int ScreenHeight = 720;
     
@@ -62,12 +61,9 @@ public class Game1 : Game
         _escape = new Escape(_player, 3, false);
         _escape.AttachCamera(_camera);
         _enemy = new Enemy(_player.Position, Content.Load<Texture2D>("sprites/spritesheet"), AnimationLoader.CreatePlayerAnimations(), new ChaseMotor(_player));
-        _enemy2 = new Enemy(_player.Position, Content.Load<Texture2D>("sprites/spritesheet"), AnimationLoader.CreatePlayerAnimations(), new ChaseMotor(_player));
-        _enemy3 = new Enemy(_player.Position, Content.Load<Texture2D>("sprites/spritesheet"), AnimationLoader.CreatePlayerAnimations(), new ChaseMotor(_player));
+   
         CombatManager.AddEnemy(_enemy);
-        CombatManager.AddEnemy(_enemy2);
-        CombatManager.AddEnemy(_enemy3);
-       
+
         UiLoader.Load(Content);
     }
 
@@ -91,8 +87,7 @@ public class Game1 : Game
         
             _escape.Draw(_spriteBatch);
             _enemy.Draw(_spriteBatch);
-            _enemy2.Draw(_spriteBatch);
-            _enemy3.Draw(_spriteBatch);
+
             CombatManager.Draw(_spriteBatch);
             ItemManager.Draw(_spriteBatch);
             


### PR DESCRIPTION
ItemManager erstellt, der sich um aktive Items in der Spielwelt kümmert.
Gegenstände können von besiegten Gegnern fallen gelassen werden, jeweils Waffe oder Gegenstand.
Diese kann man mit X aufheben, dann sind sie im Inventar des Spielers und nicht mehr in der Spielwelt. 
Die Waffe wird aber ausgetauscht, das heißt die alte Waffe bleibt dann in der Welt liegen. 

Das GUI zeigt aktuell zwei Gegenstände immer an und wie viele man davon besitzt und die aktuelle Waffe. Da würde ich den Code vielleicht nochmal in Zukunft etwas anpassen, vor allem wenn weitere Gegenstände dazukommen sollten. 
Wenn man 1 oder 2 drückt kann man einen der Gegenstände nutzen, je nach Reihenfolge. 
Die Effekte sind bisher nur Lebenspunkte und XP hinzufügen. 
Beim Besiegen von Gegnern wird Gold und XP in der GUI aktualisiert.
GUI ist auch etwas größer nun. 

Gerne ein paar Mal laufen lassen und den Gegner besiegen. Der sollte aktuell immer etwas droppen, weil ich die Wahrscheinlichkeit auf 100% gesetzt habe zum Testen. 
Mal versuchen die Waffe zu wechseln oder Items aufzusammeln und zu nutzen. 

Sonst gerne Feedback geben, wenn etwas nicht passt.