### PR TITLE
Items und Shots werden bei Levelgeneration entfernt

### DIFF
--- a/Core/Escape/Escape.cs
+++ b/Core/Escape/Escape.cs
@@ -36,6 +36,8 @@ public class Escape
     }
     private void InitializeLevel()
     { 
+        CombatManager.Init();
+        ItemManager.Init();
         _currentLevel = LevelGenerator.GenerateLevel(_difficulty * 2, _difficulty * 4);
         _currentLevel.Player = _player;
         _player.Level = _currentLevel;

--- a/Core/Manager/CombatManager.cs
+++ b/Core/Manager/CombatManager.cs
@@ -15,6 +15,13 @@ public static class CombatManager
 {
     private static List<Enemy> _activeEnemies = new List<Enemy>();
     private static List<ProjectileShot> _activeShots = new List<ProjectileShot>();
+
+    public static void Init()
+    {
+        _activeEnemies = new List<Enemy>();
+        _activeShots = new List<ProjectileShot>();
+    }
+    
     public static void Update(GameTime gameTime, Player player)
     {
         CheckShotPlayerCollision(player);

--- a/Core/Manager/ItemManager.cs
+++ b/Core/Manager/ItemManager.cs
@@ -11,7 +11,7 @@ namespace ECS2022_23.Core.Manager;
 
 public static class ItemManager
 {
-    private static List<Item> _activeItems;
+    private static List<Item> _activeItems = new List<Item>();
     private static bool _keyHasDropped = false;
     
     public static void Init()

--- a/Core/Screens/GameplayScreen.cs
+++ b/Core/Screens/GameplayScreen.cs
@@ -81,7 +81,6 @@ internal class GameplayScreen : GameScreen
         ItemLoader.Load(content);
         SoundManager.Initialize();
         UiLoader.Load(content, ScreenManager.GraphicsDevice);
-        ItemManager.Init();
 
         _player = new Player(content.Load<Texture2D>("sprites/astro"), AnimationLoader.CreatePlayerAnimations())
         {


### PR DESCRIPTION
Anstatt im GameplayScreen beim Starten des Spiels wird nun in InitializeLevel() einmal für den CombatManager die Shots und alten Gegner und für den ItemManager die Items entfernt. So sollten beim Neustart oder Wechseln in das nächste Level alte Items oder Schüsse nicht mehr existieren. 
Gerne nochmal testen, falls mir etwas entgangen sein sollte.