### PR TITLE
Animationen in Screens und Waffen Animation für Up + Down

### DIFF
--- a/Core/Animations/Animation.cs
+++ b/Core/Animations/Animation.cs
@@ -9,7 +9,7 @@ public class Animation
     public bool FlipX { get; set; }
     public bool FlipY { get; set; }
     public Vector2 StartFrame { get; }
-    public float FrameSpeed { get; }
+    public float FrameSpeed { get; set; }
     public readonly bool IsLooped;
 
     public Texture2D Texture

--- a/Core/Animations/Animation.cs
+++ b/Core/Animations/Animation.cs
@@ -8,7 +8,7 @@ public class Animation
     private Texture2D _texture;
     public bool FlipX { get; set; }
     public bool FlipY { get; set; }
-    public Vector2 StartFrame { get; }
+    public Point StartFrame { get; }
     public float FrameSpeed { get; set; }
     public readonly bool IsLooped;
 
@@ -24,7 +24,7 @@ public class Animation
 
     public int FrameCount { get; set; }
 
-    public Animation(Texture2D texture, int width, int height, int frameCount, Vector2 startFrame, bool isLooped)
+    public Animation(Texture2D texture, int width, int height, int frameCount, Point startFrame, bool isLooped)
     {
         _texture = texture;
         Width = width;
@@ -35,7 +35,7 @@ public class Animation
         IsLooped = isLooped;
     }
     
-    public Animation(Texture2D texture, int width, int height, int frameCount, Vector2 startFrame, bool isLooped, bool flipX, bool flipY) 
+    public Animation(Texture2D texture, int width, int height, int frameCount, Point startFrame, bool isLooped, bool flipX, bool flipY) 
         : this(texture, width, height, frameCount, startFrame, isLooped)
     {
         FlipX = flipX;

--- a/Core/Entities/Items/Weapon.cs
+++ b/Core/Entities/Items/Weapon.cs
@@ -71,10 +71,10 @@ public class Weapon : Item
                 SetAnimation(AnimationType.AttackLeft);
                 break;
             case (int)Direction.Up:
-                //_weapon.SetAnimation("AttackUp");
+                SetAnimation(AnimationType.AttackUp);
                 break;
             case (int)Direction.Down:
-                //_weapon.SetAnimation("AttackDown");
+                SetAnimation(AnimationType.AttackDown);
                 break;
             case (int) Direction.None:
                 SetAnimation(AnimationType.AttackRight);

--- a/Core/Loader/AnimationLoader.cs
+++ b/Core/Loader/AnimationLoader.cs
@@ -36,48 +36,48 @@ public static class AnimationLoader
         {
             {
                AnimationType.WalkUp,
-                new Animation(_texturePink, 16, 16, 6, new Vector2(1, 5), true)
+                new Animation(_texturePink, 16, 16, 6, new Point(1, 5), true)
             },
             {
                 AnimationType.WalkRight,
-                new Animation(_texturePink, 16, 16, 6, new Vector2(1, 4), true)
+                new Animation(_texturePink, 16, 16, 6, new Point(1, 4), true)
             },
             {
                 AnimationType.WalkLeft,
-                new Animation(_texturePink, 16, 16, 6, new Vector2(1, 4), true, true,
+                new Animation(_texturePink, 16, 16, 6, new Point(1, 4), true, true,
                     false)
             },
             {
                 AnimationType.WalkDown,
-                new Animation(_texturePink, 16, 16, 6, new Vector2(1, 3), true)
+                new Animation(_texturePink, 16, 16, 6, new Point(1, 3), true)
             },
             {
                 AnimationType.AttackRight,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(6, 6), false)
+                new Animation(_texturePink, 16, 16, 3, new Point(6, 6), false)
             },
             {
                 AnimationType.AttackLeft,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(6, 6), false, true, false)
+                new Animation(_texturePink, 16, 16, 3, new Point(6, 6), false, true, false)
             },
             {
                 AnimationType.AttackUp,
-                new Animation(_texturePink, 16, 16, 2, new Vector2(9, 6), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(9, 6), false)
             },
             {
                 AnimationType.AttackDown,
-                new Animation(_texturePink, 16, 16, 2, new Vector2(11, 6), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(11, 6), false)
             },
             {
                 AnimationType.Hurt,
-                new Animation(_texturePink, 16, 16, 2, new Vector2(2, 6), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(2, 6), false)
             },
             {
                 AnimationType.Death,
-                new Animation(_texturePink, 16, 16, 1, new Vector2(4, 6), true)
+                new Animation(_texturePink, 16, 16, 1, new Point(4, 6), true)
             },
             {
                 AnimationType.Default,
-                new Animation(_texturePink, 16, 16, 7, new Vector2(1, 2), true)
+                new Animation(_texturePink, 16, 16, 7, new Point(1, 2), true)
             }
         };
     }
@@ -88,39 +88,39 @@ public static class AnimationLoader
         {
             {
                 AnimationType.Walk,
-                new Animation(_texturePink, 16, 16, 2, new Vector2(10, 1), true)
+                new Animation(_texturePink, 16, 16, 2, new Point(10, 1), true)
             },
             {
                 AnimationType.WalkRight,
-                new Animation(_texturePink, 16, 16, 2, new Vector2(10, 1), true, true, false)
+                new Animation(_texturePink, 16, 16, 2, new Point(10, 1), true, true, false)
             },
             {
                 AnimationType.WalkLeft,
-                new Animation(_texturePink, 16, 16, 2, new Vector2(10, 1), true)
+                new Animation(_texturePink, 16, 16, 2, new Point(10, 1), true)
             },
             {
                 AnimationType.WalkUp,
-                new Animation(_texturePink, 16, 16, 2, new Vector2(10, 1), true, true, false)
+                new Animation(_texturePink, 16, 16, 2, new Point(10, 1), true, true, false)
             },
             {
                 AnimationType.WalkDown,
-                new Animation(_texturePink, 16, 16, 2, new Vector2(10, 1), true, true, false)
+                new Animation(_texturePink, 16, 16, 2, new Point(10, 1), true, true, false)
             },
             {
                 AnimationType.Attack,
-                new Animation(_texturePink, 16, 16, 5, new Vector2(10, 1), false)
+                new Animation(_texturePink, 16, 16, 5, new Point(10, 1), false)
             },
             {
                 AnimationType.Hurt,
-                new Animation(_texturePink, 16, 16, 1, new Vector2(15, 1), false)
+                new Animation(_texturePink, 16, 16, 1, new Point(15, 1), false)
             },
             {
                 AnimationType.Death,
-                new Animation(_texturePink, 16, 16, 1, new Vector2(14, 1), true)
+                new Animation(_texturePink, 16, 16, 1, new Point(14, 1), true)
             },
             {
                 AnimationType.Default,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(10, 1), true)
+                new Animation(_texturePink, 16, 16, 3, new Point(10, 1), true)
             }
         };
     }
@@ -131,39 +131,39 @@ public static class AnimationLoader
         {
             {
                 AnimationType.Walk,
-                new Animation(_texturePink, 16, 16, 4, new Vector2(10, 2), true)
+                new Animation(_texturePink, 16, 16, 4, new Point(10, 2), true)
             },
             {
                 AnimationType.WalkRight,
-                new Animation(_texturePink, 16, 16, 4, new Vector2(10, 2), true, true, false)
+                new Animation(_texturePink, 16, 16, 4, new Point(10, 2), true, true, false)
             },
             {
                 AnimationType.WalkLeft,
-                new Animation(_texturePink, 16, 16, 4, new Vector2(10, 2), true)
+                new Animation(_texturePink, 16, 16, 4, new Point(10, 2), true)
             },
             {
                 AnimationType.WalkUp,
-                new Animation(_texturePink, 16, 16, 4, new Vector2(10, 2), true, true, false)
+                new Animation(_texturePink, 16, 16, 4, new Point(10, 2), true, true, false)
             },
             {
                 AnimationType.WalkDown,
-                new Animation(_texturePink, 16, 16, 4, new Vector2(10, 2), true, true, false)
+                new Animation(_texturePink, 16, 16, 4, new Point(10, 2), true, true, false)
             },
             {
                 AnimationType.Attack,
-                new Animation(_texturePink, 16, 16, 2, new Vector2(12, 2), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(12, 2), false)
             },
             {
                 AnimationType.Hurt,
-                new Animation(_texturePink, 16, 16, 1, new Vector2(14, 2), false)
+                new Animation(_texturePink, 16, 16, 1, new Point(14, 2), false)
             },
             {
                 AnimationType.Death,
-                new Animation(_texturePink, 16, 16, 1, new Vector2(15, 2), true)
+                new Animation(_texturePink, 16, 16, 1, new Point(15, 2), true)
             },
             {
                 AnimationType.Default,
-                new Animation(_texturePink, 16, 16, 4, new Vector2(10, 2), true)
+                new Animation(_texturePink, 16, 16, 4, new Point(10, 2), true)
             }
         };
     }
@@ -173,23 +173,23 @@ public static class AnimationLoader
         {
             {
                 AnimationType.WalkRight,
-                new Animation(_textureRed, 16, 16, 2, new Vector2(4, 2), true)
+                new Animation(_textureRed, 16, 16, 2, new Point(4, 2), true)
             },
             {
                 AnimationType.WalkLeft,
-                new Animation(_textureRed, 16, 16, 2, new Vector2(4, 2), true, true, false)
+                new Animation(_textureRed, 16, 16, 2, new Point(4, 2), true, true, false)
             },
             {
                 AnimationType.WalkUp,
-                new Animation(_textureRed, 16, 16, 2, new Vector2(2, 2), true)
+                new Animation(_textureRed, 16, 16, 2, new Point(2, 2), true)
             },
             {
                 AnimationType.WalkDown,
-                new Animation(_textureRed, 16, 16, 2, new Vector2(0, 2), true)
+                new Animation(_textureRed, 16, 16, 2, new Point(0, 2), true)
             },
             {
                 AnimationType.Default,
-                new Animation(_textureRed, 16, 16, 2, new Vector2(2, 2), true)
+                new Animation(_textureRed, 16, 16, 2, new Point(2, 2), true)
             },
         };
     }
@@ -200,19 +200,19 @@ public static class AnimationLoader
         {
             {
                 AnimationType.AttackRight,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(13, 6), false)
+                new Animation(_texturePink, 16, 16, 3, new Point(13, 6), false)
             },
             {
                 AnimationType.AttackLeft,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(13, 6), false, true, false)
+                new Animation(_texturePink, 16, 16, 3, new Point(13, 6), false, true, false)
             },
             {
                 AnimationType.AttackUp,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(13, 6), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(16, 2), false,false, true)
             },
             {
                 AnimationType.AttackDown,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(13, 6), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(16, 2), false, true, true)
             }
         };
     }
@@ -223,19 +223,19 @@ public static class AnimationLoader
         {
             {
                 AnimationType.AttackRight,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(16, 5), false)
+                new Animation(_texturePink, 16, 16, 3, new Point(16, 5), false)
             },
             {
                 AnimationType.AttackLeft,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(16, 5), false, true, false)
+                new Animation(_texturePink, 16, 16, 3, new Point(16, 5), false, true, false)
             },
             {
                 AnimationType.AttackUp,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(16, 5), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(16, 1), false, false, true)
             },
             {
                 AnimationType.AttackDown,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(16, 5), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(16, 1), false, true, false)
             }
         };
     }
@@ -246,19 +246,19 @@ public static class AnimationLoader
         {
             {
                 AnimationType.AttackRight,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(13, 5), false)
+                new Animation(_texturePink, 16, 16, 3, new Point(13, 5), false)
             },
             {
                 AnimationType.AttackLeft,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(13, 5), false, true, false)
+                new Animation(_texturePink, 16, 16, 3, new Point(13, 5), false, true, false)
             },
             {
                 AnimationType.AttackUp,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(13, 5), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(18, 2), false, false, true)
             },
             {
                 AnimationType.AttackDown,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(13, 5), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(18, 2), false, true, false)
             }
         };
     }
@@ -269,19 +269,19 @@ public static class AnimationLoader
         {
             {
                 AnimationType.AttackRight,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(19, 6), false)
+                new Animation(_texturePink, 16, 16, 3, new Point(19, 6), false)
             },
             {
                 AnimationType.AttackLeft,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(19, 6), false, true, false)
+                new Animation(_texturePink, 16, 16, 3, new Point(19, 6), false, true, false)
             },
             {
                 AnimationType.AttackUp,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(19, 6), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(20, 2), false, false, true)
             },
             {
                 AnimationType.AttackDown,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(19, 6), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(20, 2), false, true, false)
             }
         };
     }
@@ -292,19 +292,19 @@ public static class AnimationLoader
         {
             {
                 AnimationType.AttackRight,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(16, 6), false)
+                new Animation(_texturePink, 16, 16, 3, new Point(16, 6), false)
             },
             {
                 AnimationType.AttackLeft,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(16, 6), false, true, false)
+                new Animation(_texturePink, 16, 16, 3, new Point(16, 6), false, true, false)
             },
             {
                 AnimationType.AttackUp,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(16, 6), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(18, 1), false, false, true)
             },
             {
                 AnimationType.AttackDown,
-                new Animation(_texturePink, 16, 16, 3, new Vector2(16, 6), false)
+                new Animation(_texturePink, 16, 16, 2, new Point(18, 1), false, true, false)
             }
         };
     }

--- a/Core/Manager/AnimationManager.cs
+++ b/Core/Manager/AnimationManager.cs
@@ -70,7 +70,7 @@ public class AnimationManager
     public void Draw(SpriteBatch spriteBatch, Vector2 position)
     {
         if (CurrentAnimation == null) return;
-        var sourceRec = new Rectangle((int)(_currentFrame + CurrentAnimation.StartFrame.X) * CurrentAnimation.Width, (int)CurrentAnimation.StartFrame.Y * CurrentAnimation.Height, CurrentAnimation.Width, CurrentAnimation.Height);
+        var sourceRec = new Rectangle((_currentFrame + CurrentAnimation.StartFrame.X) * CurrentAnimation.Width, CurrentAnimation.StartFrame.Y * CurrentAnimation.Height, CurrentAnimation.Width, CurrentAnimation.Height);
 
         try
         {
@@ -100,7 +100,7 @@ public class AnimationManager
     public void Draw(SpriteBatch spriteBatch, Vector2 position, Color color)
     {
         if (CurrentAnimation == null) return;
-        var sourceRec = new Rectangle((int)(_currentFrame + CurrentAnimation.StartFrame.X) * CurrentAnimation.Width, (int)CurrentAnimation.StartFrame.Y * CurrentAnimation.Height, CurrentAnimation.Width, CurrentAnimation.Height);
+        var sourceRec = new Rectangle((_currentFrame + CurrentAnimation.StartFrame.X) * CurrentAnimation.Width, CurrentAnimation.StartFrame.Y * CurrentAnimation.Height, CurrentAnimation.Width, CurrentAnimation.Height);
         var scale = new Vector2(1, 1);
 
         try

--- a/Core/Manager/AnimationManager.cs
+++ b/Core/Manager/AnimationManager.cs
@@ -31,7 +31,7 @@ public class AnimationManager
         if (!CurrentAnimation.IsLooped) AnimationFinished = false;
     }
 
-    private void Stop()
+    public void Stop()
     {
         AnimationFinished = true;
         CurrentAnimation = null;

--- a/Core/Screens/BackgroundScreen.cs
+++ b/Core/Screens/BackgroundScreen.cs
@@ -59,11 +59,6 @@ namespace ECS2022_23.Core.Screens
                 content = new ContentManager(ScreenManager.Game.Services, "Content/gameStateManagement");
 
             backgroundTexture = content.Load<Texture2D>("background");
-            var _texturePink = content.Load<Texture2D>("../sprites/spritesheet");
-            _idleAnimation = new Animation(_texturePink, 16, 16, 7, new Vector2(1, 2), true);
-            _animationManager = new AnimationManager();
-            _animationManager.SetScale(new Vector2(2,2));
-            _animationManager.Play(_idleAnimation);
         }
 
         /// <summary>
@@ -89,7 +84,6 @@ namespace ECS2022_23.Core.Screens
                                                        bool coveredByOtherScreen)
         {
             base.Update(gameTime, otherScreenHasFocus, false);
-            _animationManager.Update(gameTime);
         }
 
         /// <summary>
@@ -105,7 +99,6 @@ namespace ECS2022_23.Core.Screens
 
             spriteBatch.Draw(backgroundTexture, fullscreen,
                              new Color(TransitionAlpha, TransitionAlpha, TransitionAlpha));
-            _animationManager.Draw(spriteBatch, new Vector2(16*18, 16*21));
             spriteBatch.End();
         }
 

--- a/Core/Screens/GameOverScreen.cs
+++ b/Core/Screens/GameOverScreen.cs
@@ -34,20 +34,20 @@ internal class GameOverScreen : MenuScreen
     { 
         if (content == null)
             content = new ContentManager(ScreenManager.Game.Services, "Content/gameStateManagement");
-        Texture2D = content.Load<Texture2D>("../sprites/spritesheet");
+        Spritesheet = content.Load<Texture2D>("../sprites/spritesheet");
 
-        if (Texture2D != null)
+        if (Spritesheet != null)
         {
             if (gameIsWon)
             {
                 //Walk Up Animation
-                Animation = new Animation(Texture2D, 16, 16, 6, new Vector2(1, 5), true);
+                Animation = new Animation(Spritesheet, 16, 16, 6, new Vector2(1, 5), true);
                 AnimationPosition = new Vector2(16 * 18, 16 * 21);
             }
             else
             {
                 //Death Animation
-                Animation = new Animation(Texture2D, 16, 16, 1, new Vector2(4, 6), true);
+                Animation = new Animation(Spritesheet, 16, 16, 1, new Vector2(4, 6), true);
                 AnimationPosition = new Vector2(16 * 18, 16 * 21);
             }
 

--- a/Core/Screens/GameOverScreen.cs
+++ b/Core/Screens/GameOverScreen.cs
@@ -41,13 +41,13 @@ internal class GameOverScreen : MenuScreen
             if (gameIsWon)
             {
                 //Walk Up Animation
-                Animation = new Animation(Spritesheet, 16, 16, 6, new Vector2(1, 5), true);
+                Animation = new Animation(Spritesheet, 16, 16, 6, new Point(1, 5), true);
                 AnimationPosition = new Vector2(16 * 18, 16 * 21);
             }
             else
             {
                 //Death Animation
-                Animation = new Animation(Spritesheet, 16, 16, 1, new Vector2(4, 6), true);
+                Animation = new Animation(Spritesheet, 16, 16, 1, new Point(4, 6), true);
                 AnimationPosition = new Vector2(16 * 18, 16 * 21);
             }
             Animation.FrameSpeed = FrameSpeed;

--- a/Core/Screens/GameOverScreen.cs
+++ b/Core/Screens/GameOverScreen.cs
@@ -1,17 +1,25 @@
 #region Using Statements
 
+using ECS2022_23.Core.Animations;
 using GameStateManagement;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
 
 #endregion Using Statements
 
 namespace ECS2022_23.Core.Screens;
 internal class GameOverScreen : MenuScreen
 {
+    private ContentManager content;
+    private int EndPosition;
+    private bool gameIsWon;
+    
     #region Initialization
     public GameOverScreen(bool gameIsWon)
         : base(gameIsWon ? "You escaped!" : "Game Over" )
     {
-
+        this.gameIsWon = gameIsWon;
         MenuEntry replayGameMenuEntry = new MenuEntry("Restart Game");
         MenuEntry backToMenu = new MenuEntry("Return to Menu");
             
@@ -20,6 +28,32 @@ internal class GameOverScreen : MenuScreen
             
         MenuEntries.Add(replayGameMenuEntry);
         MenuEntries.Add(backToMenu);
+    }
+    
+    public override void LoadContent()
+    { 
+        if (content == null)
+            content = new ContentManager(ScreenManager.Game.Services, "Content/gameStateManagement");
+        Texture2D = content.Load<Texture2D>("../sprites/spritesheet");
+
+        if (Texture2D != null)
+        {
+            if (gameIsWon)
+            {
+                //Walk Up Animation
+                Animation = new Animation(Texture2D, 16, 16, 6, new Vector2(1, 5), true);
+                AnimationPosition = new Vector2(16 * 18, 16 * 21);
+            }
+            else
+            {
+                //Death Animation
+                Animation = new Animation(Texture2D, 16, 16, 1, new Vector2(4, 6), true);
+                AnimationPosition = new Vector2(16 * 18, 16 * 21);
+            }
+
+            EndPosition = (int) AnimationPosition.Y;
+            SetAnimation(Animation);
+        }
     }
 
     #endregion Initialization
@@ -36,4 +70,19 @@ internal class GameOverScreen : MenuScreen
             new MainMenuScreen());
     }
     #endregion Handle Input
+
+    public override void Update(GameTime gameTime, bool otherScreenHasFocus, bool coveredByOtherScreen)
+    {
+        if (gameIsWon)
+        {
+            AnimationPosition += new Vector2(0, -4);
+            if (AnimationPosition.Y <= EndPosition - 16*3)
+            {
+                //TODO Choose EndPosition for ending animation
+                //Stop walking when through door
+                StopAnimation();
+            }
+        }
+        base.Update(gameTime, otherScreenHasFocus, coveredByOtherScreen);
+    }
 }

--- a/Core/Screens/GameOverScreen.cs
+++ b/Core/Screens/GameOverScreen.cs
@@ -12,7 +12,7 @@ namespace ECS2022_23.Core.Screens;
 internal class GameOverScreen : MenuScreen
 {
     private ContentManager content;
-    private int EndPosition;
+    private float StartPosition;
     private bool gameIsWon;
     
     #region Initialization
@@ -50,8 +50,8 @@ internal class GameOverScreen : MenuScreen
                 Animation = new Animation(Spritesheet, 16, 16, 1, new Vector2(4, 6), true);
                 AnimationPosition = new Vector2(16 * 18, 16 * 21);
             }
-
-            EndPosition = (int) AnimationPosition.Y;
+            Animation.FrameSpeed = FrameSpeed;
+            StartPosition = AnimationPosition.Y;
             SetAnimation(Animation);
         }
     }
@@ -75,10 +75,10 @@ internal class GameOverScreen : MenuScreen
     {
         if (gameIsWon)
         {
-            AnimationPosition += new Vector2(0, -4);
-            if (AnimationPosition.Y <= EndPosition - 16*3)
+            AnimationPosition += new Vector2(0, -0.5f);
+            //Check if at door 
+            if (AnimationPosition.Y <= StartPosition - 16*5)
             {
-                //TODO Choose EndPosition for ending animation
                 //Stop walking when through door
                 StopAnimation();
             }

--- a/Core/Screens/GameplayScreen.cs
+++ b/Core/Screens/GameplayScreen.cs
@@ -87,7 +87,7 @@ internal class GameplayScreen : GameScreen
             Weapon = ItemLoader.CreatePhaserWeapon(Vector2.Zero)
         };
         InventoryManager.Init(_player);
-        _escape = new Escape(_player, 3,3);
+        _escape = new Escape(_player, 3,1);
         _escape.AttachCamera(_camera);
             
         // once the load has finished, we use ResetElapsedTime to tell the game's

--- a/Core/Screens/MainMenuScreen.cs
+++ b/Core/Screens/MainMenuScreen.cs
@@ -60,7 +60,7 @@ internal class MainMenuScreen : MenuScreen
 
         if (Spritesheet != null)
         {
-            Animation =  new Animation(Spritesheet, 16, 16, 7, new Vector2(1, 2), true);
+            Animation =  new Animation(Spritesheet, 16, 16, 7, new Point(1, 2), true);
             AnimationPosition = new Vector2(16 * 18, 16 * 21);
             Animation.FrameSpeed = FrameSpeed;
             SetAnimation(Animation);

--- a/Core/Screens/MainMenuScreen.cs
+++ b/Core/Screens/MainMenuScreen.cs
@@ -11,8 +11,11 @@
 
 #region Using Statements
 
+using ECS2022_23.Core.Animations;
 using GameStateManagement;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
 
 #endregion Using Statements
 
@@ -23,6 +26,8 @@ namespace ECS2022_23.Core.Screens;
 /// </summary>
 internal class MainMenuScreen : MenuScreen
 {
+    private ContentManager content;
+    
     #region Initialization
 
     /// <summary>
@@ -47,6 +52,20 @@ internal class MainMenuScreen : MenuScreen
         MenuEntries.Add(exitMenuEntry);
     }
 
+    public override void LoadContent()
+    { 
+        if (content == null)
+            content = new ContentManager(ScreenManager.Game.Services, "Content/gameStateManagement");
+        Texture2D = content.Load<Texture2D>("../sprites/spritesheet");
+
+        if (Texture2D != null)
+        {
+            Animation =  new Animation(Texture2D, 16, 16, 7, new Vector2(1, 2), true);
+            AnimationPosition = new Vector2(16 * 18, 16 * 21);
+            SetAnimation(Animation);
+        }
+    }
+    
     #endregion Initialization
 
     #region Handle Input

--- a/Core/Screens/MainMenuScreen.cs
+++ b/Core/Screens/MainMenuScreen.cs
@@ -56,11 +56,11 @@ internal class MainMenuScreen : MenuScreen
     { 
         if (content == null)
             content = new ContentManager(ScreenManager.Game.Services, "Content/gameStateManagement");
-        Texture2D = content.Load<Texture2D>("../sprites/spritesheet");
+        Spritesheet = content.Load<Texture2D>("../sprites/spritesheet");
 
-        if (Texture2D != null)
+        if (Spritesheet != null)
         {
-            Animation =  new Animation(Texture2D, 16, 16, 7, new Vector2(1, 2), true);
+            Animation =  new Animation(Spritesheet, 16, 16, 7, new Vector2(1, 2), true);
             AnimationPosition = new Vector2(16 * 18, 16 * 21);
             SetAnimation(Animation);
         }

--- a/Core/Screens/MainMenuScreen.cs
+++ b/Core/Screens/MainMenuScreen.cs
@@ -62,6 +62,7 @@ internal class MainMenuScreen : MenuScreen
         {
             Animation =  new Animation(Spritesheet, 16, 16, 7, new Vector2(1, 2), true);
             AnimationPosition = new Vector2(16 * 18, 16 * 21);
+            Animation.FrameSpeed = FrameSpeed;
             SetAnimation(Animation);
         }
     }

--- a/Core/Screens/MenuScreen.cs
+++ b/Core/Screens/MenuScreen.cs
@@ -13,8 +13,11 @@
 
 using System;
 using System.Collections.Generic;
+using ECS2022_23.Core.Animations;
+using ECS2022_23.Core.Manager;
 using GameStateManagement;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Graphics;
 
 #endregion Using Statements
@@ -33,6 +36,10 @@ internal abstract class MenuScreen : GameScreen
     private int selectedEntry;
     private string menuTitle;
 
+    private AnimationManager _animationManager = new AnimationManager();
+    protected Vector2 AnimationPosition;
+    protected Animation Animation;
+    protected Texture2D Texture2D;
 
     #endregion Fields
 
@@ -57,6 +64,7 @@ internal abstract class MenuScreen : GameScreen
 
         TransitionOnTime = TimeSpan.FromSeconds(0.5);
         TransitionOffTime = TimeSpan.FromSeconds(0.5);
+        _animationManager.SetScale(new Vector2(2,2));
     }
 
     #endregion Initialization
@@ -181,6 +189,7 @@ internal abstract class MenuScreen : GameScreen
 
             menuEntries[i].Update(this, isSelected, gameTime);
         }
+        _animationManager.Update(gameTime);
     }
 
     /// <summary>
@@ -217,6 +226,21 @@ internal abstract class MenuScreen : GameScreen
             titleOrigin, titleScale, SpriteEffects.None, 0);
             
         spriteBatch.End();
+        
+        spriteBatch.Begin(samplerState: SamplerState.PointClamp);
+        _animationManager.Draw(spriteBatch, AnimationPosition);
+        spriteBatch.End();
+    }
+
+    protected void SetAnimation(Animation animation)
+    {
+        _animationManager ??= new AnimationManager();
+        _animationManager.Play(animation);
+    }
+
+    protected void StopAnimation()
+    {
+        _animationManager.Stop();
     }
 
     protected virtual Vector2 PlaceTitle(GraphicsDevice graphics)

--- a/Core/Screens/MenuScreen.cs
+++ b/Core/Screens/MenuScreen.cs
@@ -37,6 +37,7 @@ internal abstract class MenuScreen : GameScreen
     private string menuTitle;
 
     private AnimationManager _animationManager = new();
+    protected const float FrameSpeed = 0.4f;
     protected Vector2 AnimationPosition;
     protected Animation Animation;
     protected Texture2D Spritesheet;

--- a/Core/Screens/MenuScreen.cs
+++ b/Core/Screens/MenuScreen.cs
@@ -36,10 +36,10 @@ internal abstract class MenuScreen : GameScreen
     private int selectedEntry;
     private string menuTitle;
 
-    private AnimationManager _animationManager = new AnimationManager();
+    private AnimationManager _animationManager = new();
     protected Vector2 AnimationPosition;
     protected Animation Animation;
-    protected Texture2D Texture2D;
+    protected Texture2D Spritesheet;
 
     #endregion Fields
 


### PR DESCRIPTION
Je nach Screen werden andere Animationen geladen und abgespielt. Die Framespeed habe ich hier reduziert, kann bei Bedarf nochmal angepasst werden im MenuScreen, falls zu langsam oder schnell. Es würde dann nur noch die Spind Screen Animation fehlen.
Sonst noch kleine Änderungen in der Animation Klasse und das Spritesheet erweitert um die Waffenanimationen. Diese werden nun auch abgespielt.