### PR TITLE
Unverwundbarkeit auch mit Rüstung

### DIFF
--- a/Core/Entities/Characters/Player.cs
+++ b/Core/Entities/Characters/Player.cs
@@ -15,11 +15,23 @@ namespace ECS2022_23.Core.Entities.Characters;
 
 public class Player : Character
 {
+    private bool _invincible;
+
+    public bool Invincible
+    {
+        get => _invincible;
+        set
+        {
+            _invincible = value;
+            if (value) AnimationManager.StartColorChange();
+            else AnimationManager.StopColorChange();
+        }
+    }
+    
     public float EP;
     public float Level;
 
     public float Armor;
-    public bool Invincible;
     public bool ImmuneToWater = false;
 
     public DeathCause DeathCause;
@@ -81,14 +93,6 @@ public class Player : Character
         }
         else
         {
-            if (Invincible)
-            {
-                AnimationManager.StartColorChange();
-            }
-            else
-            {
-                AnimationManager.StopColorChange();
-            }
             AnimationManager.Draw(spriteBatch, Position);
             Weapon?.Draw(spriteBatch);
         }
@@ -262,20 +266,20 @@ public class Player : Character
         {
             HP += Armor;
             Armor = 0;
-            Invincible = true;
             SetAnimation(AnimationType.Hurt);
             SoundManager.Play(DamageSound);
         }
            
         if (!IsAlive())
         {
-            Invincible = true;
             DeathCause = Helper.Transform.EntityToDeathCause(entity);
             SetAnimation(AnimationType.Death);
         }
+
+        Invincible = true;
     }
 
-    public void LevelUp()
+    private void LevelUp()
     {
         if (25 <= EP)
         {
@@ -290,4 +294,5 @@ public class Player : Character
     {
         AimDirection = getAimDirection;
     }
+
 }

--- a/Core/Manager/CombatManager.cs
+++ b/Core/Manager/CombatManager.cs
@@ -32,7 +32,6 @@ public static class CombatManager
     {
         if (player.Invincible)
         {
-            //if player was hurt, wait for cooldown until player can take damage again 
             _damageCooldown.Update(gameTime);
             if (_damageCooldown.LimitReached())
             {
@@ -59,7 +58,6 @@ public static class CombatManager
 
         foreach (var enemy in _activeEnemies)
         {
-            //muss noch mit mehreren enemies getestet werden (gleichzeitige Angriffe z.B.)
             if (enemy.IsAlive())
             {
                 CheckShotEnemyCollision(enemy, player);


### PR DESCRIPTION
Wenn der Spieler Schaden nimmt und noch Rüstung hat, dann wird dieser trotzdem kurz unverwundbar genauso wie mit ohne Rüstung. 
Habe auch aus dem Invincible Attribut ein Property gemacht, damit die Funktion zum Beginnen und Starten des Farbwechsels nicht in jedem Update des Players aufgerufen / geprüft werden müssen, sondern nur einmal beim Setzen des Wertes. 